### PR TITLE
main: fix underflow when decreasing brightness

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,8 @@ fn main() -> Result<()> {
             let max = read_max_brightness(&device)?;
             let amount = amount.to_absolute(max);
             let current = read_brightness(&device)?;
-            let target = (current - amount).clamp(0, max);
+            let target = current.saturating_sub(amount).clamp(0, max);
+
 
             set_brightness(&device, current, target, duration.0, frequency, amount)
         }


### PR DESCRIPTION
Prevent integer underflow when decreasing brightness by using `saturating_sub`.

This issue in rust arises in release builds particularly, by default rust panics when you subtract with overflow on an unsigned type. (It won't panic if you run it with the --release flag).

In release mode, subtracting `amount` from `current` caused an underflow, producing a very large number that was then clamped back down to the maximum brightness. In debug mode, the same operation triggered a panic due to the underflow check.